### PR TITLE
Raise JobError

### DIFF
--- a/blitline/__init__.py
+++ b/blitline/__init__.py
@@ -154,6 +154,11 @@ class JobResult(object):
             'original_meta': r['original_meta'],
         }
         for i in r['images']:
+            error = i.get("error")
+
+            if error is not None:
+                raise JobError(200, error)
+
             iid = i.pop('image_identifier')
             output[iid] = i
         return output


### PR DESCRIPTION
It is raised when blitline errors on one or more images, even if some of
them completed successfully
